### PR TITLE
Add tool to list AWS Lambda functions

### DIFF
--- a/computeagent/ec2/tools.py
+++ b/computeagent/ec2/tools.py
@@ -261,3 +261,25 @@ def create_azure_devops_user_story(title, description, acceptance_criteria):
 
 tool_list = [start_ec2_instance, stop_ec2_instance, list_ec2_instances_by_name, send_whatsapp_message, get_billing_data]
 tool_list += [list_rds_instances, start_rds_instance, stop_rds_instance, create_azure_devops_user_story]
+
+@tool
+def list_lambda_functions():
+    """
+    Lists AWS Lambda functions with their names and statuses.
+
+    :return: A list of dictionaries containing 'FunctionName' and 'State'.
+    """
+    lambda_client = boto3.client('lambda')
+    response = lambda_client.list_functions()
+    functions = []
+    for function in response['Functions']:
+        function_name = function['FunctionName']
+        function_state = function['State'] if 'State' in function else 'Unknown'
+        functions.append({
+            'FunctionName': function_name,
+            'State': function_state
+        })
+    return functions
+
+tool_list.append(list_lambda_functions)
+


### PR DESCRIPTION
This PR introduces a new tool to list AWS Lambda functions, providing their names and statuses. This feature is part of the user story #499, enabling users to request a list of Lambda functions via WhatsApp, similar to existing EC2 and RDS functionalities.