### PR TITLE
Add tool to list AWS Lambda functions

### DIFF
--- a/computeagent/ec2/tools.py
+++ b/computeagent/ec2/tools.py
@@ -307,3 +307,25 @@ def list_lambda_functions():
 
 tool_list.append(list_lambda_functions)
 
+
+@tool
+def list_lambda_functions():
+    """
+    Lists all AWS Lambda functions with their names and statuses.
+
+    :return: A list of dictionaries containing 'FunctionName' and 'State'.
+    """
+    lambda_client = boto3.client('lambda')
+    response = lambda_client.list_functions()
+    functions = []
+    for function in response['Functions']:
+        function_name = function['FunctionName']
+        function_state = function['State']
+        functions.append({
+            'FunctionName': function_name,
+            'State': function_state
+        })
+    return functions
+
+tool_list.append(list_lambda_functions)
+

--- a/computeagent/template.yaml
+++ b/computeagent/template.yaml
@@ -79,11 +79,6 @@ Resources:
             - Effect: Allow
               Action:
                 - lambda:ListFunctions
-        - Statement:
-            - Effect: Allow
-              Action:
-                - lambda:ListFunctions
-              Resource: "*"
               Resource: "*"
         - Statement:
             - Effect: Allow

--- a/computeagent/template.yaml
+++ b/computeagent/template.yaml
@@ -79,6 +79,11 @@ Resources:
             - Effect: Allow
               Action:
                 - lambda:ListFunctions
+        - Statement:
+            - Effect: Allow
+              Action:
+                - lambda:ListFunctions
+              Resource: "*"
               Resource: "*"
         - Statement:
             - Effect: Allow


### PR DESCRIPTION
This PR introduces a new tool to list AWS Lambda functions, providing their names and statuses. The tool is integrated into the existing system to allow users to interact with it via WhatsApp. Additionally, necessary permissions have been added to the AWS SAM template to support this functionality.