### PR TITLE
Add tool to list AWS Lambda functions

### DIFF
--- a/computeagent/ec2/tools.py
+++ b/computeagent/ec2/tools.py
@@ -261,3 +261,25 @@ def create_azure_devops_user_story(title, description, acceptance_criteria):
 
 tool_list = [start_ec2_instance, stop_ec2_instance, list_ec2_instances_by_name, send_whatsapp_message, get_billing_data]
 tool_list += [list_rds_instances, start_rds_instance, stop_rds_instance, create_azure_devops_user_story]
+
+@tool
+def list_lambda_functions():
+    """
+    Lists all AWS Lambda functions with their names and statuses.
+
+    :return: A list of dictionaries containing 'FunctionName' and 'State'.
+    """
+    lambda_client = boto3.client('lambda')
+    response = lambda_client.list_functions()
+    functions = []
+    for function in response['Functions']:
+        function_name = function['FunctionName']
+        function_state = function['State'] if 'State' in function else 'Unknown'
+        functions.append({
+            'FunctionName': function_name,
+            'State': function_state
+        })
+    return functions
+
+tool_list.append(list_lambda_functions)
+

--- a/computeagent/template.yaml
+++ b/computeagent/template.yaml
@@ -86,11 +86,12 @@ Resources:
         - Statement:
             - Effect: Allow
               Action:
+                - lambda:ListFunctions
+              Resource: "*" 
         - Statement:
             - Effect: Allow
               Action:
-                - lambda:ListFunctions
-              Resource: "*"                - rds:DescribeDBInstances  # List RDS instances
+                - rds:DescribeDBInstances  # List RDS instances
                 - rds:StartDBInstance     # Start an RDS instance
                 - rds:StopDBInstance      # Stop an RDS instance
               Resource: "*"  # You can restrict this to specific RDS instances if needed

--- a/computeagent/template.yaml
+++ b/computeagent/template.yaml
@@ -86,7 +86,11 @@ Resources:
         - Statement:
             - Effect: Allow
               Action:
-                - rds:DescribeDBInstances  # List RDS instances
+        - Statement:
+            - Effect: Allow
+              Action:
+                - lambda:ListFunctions
+              Resource: "*"                - rds:DescribeDBInstances  # List RDS instances
                 - rds:StartDBInstance     # Start an RDS instance
                 - rds:StopDBInstance      # Stop an RDS instance
               Resource: "*"  # You can restrict this to specific RDS instances if needed


### PR DESCRIPTION
This pull request adds a new tool to list AWS Lambda functions, allowing users to view their Lambda functions directly through the assistant. The tool provides a list of Lambda functions with their names and statuses. Additionally, the AWS SAM template has been updated to include the necessary permissions for this functionality.