### PR TITLE
Add tool to retrieve AWS Lambda logs

### DIFF
--- a/computeagent/template.yaml
+++ b/computeagent/template.yaml
@@ -107,6 +107,11 @@ Resources:
                 - rds:StopDBInstance      # Stop an RDS instance
               Resource: "*"  # You can restrict this to specific RDS instances if needed
         - Statement:
+            - Effect: Allow
+              Action:
+                - logs:DescribeLogStreams
+                - logs:GetLogEvents
+              Resource: "*"        - Statement:
             Effect: Allow
             Action:
               - dynamodb:CreateTable

--- a/computeagent/template.yaml
+++ b/computeagent/template.yaml
@@ -111,14 +111,15 @@ Resources:
               Action:
                 - logs:DescribeLogStreams
                 - logs:GetLogEvents
-              Resource: "*"        - Statement:
-            Effect: Allow
-            Action:
-              - dynamodb:CreateTable
-              - dynamodb:DeleteTable
-              - dynamodb:DescribeTable
-              - dynamodb:UpdateTable
-            Resource: "*"
+              Resource: "*"        
+        - Statement:
+            - Effect: Allow
+              Action:
+                - dynamodb:CreateTable
+                - dynamodb:DeleteTable
+                - dynamodb:DescribeTable
+                - dynamodb:UpdateTable
+              Resource: "*"
         - Statement:
             Effect: Allow
             Action:


### PR DESCRIPTION
This PR introduces a new tool to retrieve logs for a specified AWS Lambda function. The logs can be retrieved for a specific time range and are intended to be presented in a readable format on WhatsApp. Additionally, permissions for accessing AWS CloudWatch Logs have been updated in the SAM template.