### PR TITLE
Add tool to send logs as email attachments

### DIFF
--- a/computeagent/template.yaml
+++ b/computeagent/template.yaml
@@ -96,7 +96,12 @@ Resources:
               Resource: "*"
         - Statement:
             - Effect: Allow
+        - Statement:
+            - Effect: Allow
               Action:
+                - ses:SendEmail
+                - ses:SendRawEmail
+              Resource: "*"  # You can restrict this to specific email identities if needed              Action:
                 - lambda:ListFunctions
               Resource: "*" 
         - Statement:


### PR DESCRIPTION
This PR introduces a new tool that allows users to send logs as email attachments in various formats (TXT, CSV, PDF). It includes error handling for email delivery issues and updates the permissions to allow sending emails using AWS SES.